### PR TITLE
Modernize site look and feel

### DIFF
--- a/public/styles/main.css
+++ b/public/styles/main.css
@@ -1,107 +1,203 @@
-html * {
+/* ============================================================
+   Reset & base
+   ============================================================ */
+
+*, *::before, *::after {
+  box-sizing: border-box;
   margin: 0;
+  padding: 0;
 }
 
 body {
-  color: #333;
-  font: 14px verdana, arial, helvetica, sans-serif;
-  background-color: gray;
+  background-color: #faf8f4;
+  color: #1a1a1a;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif;
+  font-size: 16px;
+  line-height: 1.6;
 }
+
+/* ============================================================
+   Page layout
+   ============================================================ */
 
 .page {
-  background: #fff url(../images/vellum-transparent-background.png) repeat;
-  margin: 20px;
-  border: thin solid;
+  background-color: #faf8f4;
+  max-width: 900px;
+  margin: 0 auto;
+  padding: 0 0 40px;
 }
 
-#expotus_dates {
+/* ============================================================
+   Site header
+   ============================================================ */
+
+header {
+  padding: 28px 20px 16px;
+  border-bottom: 2px solid #1a2744;
+  margin-bottom: 0;
+}
+
+#site-title {
+  font-family: 'Playfair Display', Georgia, serif;
+  font-size: 48px;
+  font-weight: 700;
+  line-height: 1;
+  letter-spacing: -0.02em;
+  color: #1a2744;
+}
+
+#site-title a {
+  color: #1a2744;
+  text-decoration: none;
+}
+
+#site-title a:hover {
+  color: #2c4a8c;
+}
+
+.site-tld {
+  font-size: 0.5em;
+  font-weight: 400;
+  color: #2c4a8c;
+  letter-spacing: 0;
+  vertical-align: baseline;
+  position: relative;
+  top: -0.1em;
+}
+
+#tagline {
+  font-family: 'Playfair Display', Georgia, serif;
+  font-size: 16px;
+  font-style: italic;
+  color: #666;
+  margin-top: 4px;
+}
+
+/* ============================================================
+   Navigation
+   ============================================================ */
+
+.nav {
+  border-bottom: 1px solid #d4d0c8;
+  padding: 8px 20px;
+  margin-bottom: 4px;
+}
+
+.menuButton {
   font-size: 14px;
+  font-weight: normal;
+  padding: 0 10px 0 0;
+  color: #666;
+}
+
+.menuButton:first-child {
+  padding-left: 0;
+}
+
+.menuButton a {
+  color: #2c4a8c;
+  text-decoration: none;
+}
+
+.menuButton a:hover {
+  text-decoration: underline;
+  color: #1a2744;
+}
+
+.menuButton.active {
+  font-weight: bold;
+  color: #1a2744;
+}
+
+.menuButton.active a {
+  color: #1a2744;
+}
+
+/* ============================================================
+   Body / content area
+   ============================================================ */
+
+.body {
+  margin: 0 20px 10px;
 }
 
 .about {
   padding: 20px;
 }
 
-#logo {
-  padding: 20px 20px 0 20px;
-}
-
-#tagline {
-  font: 20px times, serif;
-  font-style: italic;
-  padding: 0 20px 20px 20px;
-}
-
-a:link, a:visited, a:hover {
-  color: #666;
-  font-weight: bold;
-  text-decoration: none;
-}
-
-p {
-  padding: .5em;
-}
+/* ============================================================
+   Typography
+   ============================================================ */
 
 h1 {
-  font-weight: normal;
-  font-size: 24px;
-  margin: .8em 0 .3em 0;
+  font-family: 'Playfair Display', Georgia, serif;
+  font-size: 28px;
+  font-weight: 700;
+  color: #1a2744;
+  margin: 0.8em 0 0.4em;
+}
+
+h2 {
+  font-family: 'Playfair Display', Georgia, serif;
+  font-size: 22px;
+  font-weight: 700;
+  color: #1a2744;
+  margin: 0.8em 0 0.3em;
 }
 
 h3 {
+  font-family: 'Playfair Display', Georgia, serif;
+  font-size: 18px;
+  font-weight: 700;
+  color: #1a2744;
   margin-top: 1em;
 }
 
-.body {
-  margin: 0 15px 10px 15px;
+p {
+  padding: 0.5em 0;
 }
 
-/* NAVIGATION MENU */
-
-.nav {
-  background: #fff;
-  border: 1px solid #ccc;
-  border-style: solid none;
-  margin-top: 5px;
-  padding: 7px 12px;
+a:link, a:visited {
+  color: #2c4a8c;
+  text-decoration: none;
 }
 
-.menuButton {
-  color: #999;
-  font-size: 10px;
-  font-weight: bold;
-  padding: 0 6px;
-}
-.menuButton a {
-  color: #333;
+a:hover {
+  color: #1a2744;
+  text-decoration: underline;
 }
 
-/* TABLES */
+/* ============================================================
+   Tables
+   ============================================================ */
 
 table {
-  border: 1px solid #ccc;
+  border: 1px solid #d4d0c8;
   width: 100%;
   border-collapse: collapse;
 }
 
 td, th {
-  font: 13px verdana, arial, helvetica, sans-serif;
-  line-height: 1.4;
-  padding: 5px 6px;
+  font-size: 16px;
+  line-height: 1.5;
+  padding: 8px 10px;
   text-align: left;
   vertical-align: top;
 }
 
 th {
-  background: #eee;
-  color: #666;
+  background-color: #1a2744;
+  color: #fff;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif;
   font-size: 13px;
-  font-weight: bold;
-  padding: 4px 6px;
+  font-weight: 600;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  padding: 8px 10px;
 }
 
 th a:link, th a:visited, th a:hover {
-  color: #333;
+  color: #fff;
   display: block;
   text-decoration: none;
   width: 100%;
@@ -115,37 +211,59 @@ th.asc a::after {
   content: ' \25B2';
   font-size: 8px;
 }
+
 th.desc a::after {
   content: ' \25BC';
   font-size: 8px;
 }
 
 .odd {
-  background: #f7f7f7;
+  background-color: #f3f2ef;
 }
+
 .even {
-  background: #fff;
+  background-color: #faf8f4;
 }
 
 .list {
-  padding: .5em;
+  padding: 0.5em 0;
   overflow-x: auto;
   -webkit-overflow-scrolling: touch;
 }
 
 .list th, .list td {
-  border-left: 1px solid #ddd;
-}
-.list th:hover, .list tr:hover {
-  background: #b2d1ff;
+  border-left: 1px solid #d4d0c8;
 }
 
-/* RESPONSIVE / MOBILE */
+.list tr:hover td {
+  background-color: #e8edf5;
+}
+
+#expotus_dates {
+  font-size: 16px;
+}
+
+/* ============================================================
+   Citations
+   ============================================================ */
+
+.citation {
+  font-style: italic;
+  color: #666;
+  font-size: 14px;
+}
+
+/* ============================================================
+   Responsive / mobile
+   ============================================================ */
 
 @media (max-width: 640px) {
   .page {
     margin: 0;
-    border: none;
+  }
+
+  #site-title {
+    font-size: 36px;
   }
 
   .nav {
@@ -153,29 +271,22 @@ th.desc a::after {
   }
 
   .menuButton {
-    font-size: 14px;
-    padding: 4px 8px;
+    font-size: 16px;
+    padding: 4px 10px 4px 0;
     display: inline-block;
   }
 
   .body {
-    margin: 0 10px 10px 10px;
+    margin: 0 10px 10px;
   }
 
   h1 {
-    font-size: 20px;
+    font-size: 22px;
   }
 
   #expotus_dates {
     display: block;
-    font-size: 13px;
+    font-size: 14px;
     margin-top: 4px;
   }
-}
-
-/* CITATIONS */
-
-.citation {
-  font-style: italic;
-  color: #999;
 }

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -11,14 +11,17 @@ const { title = 'exPotus.com' } = Astro.props;
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>{title}</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link href="https://fonts.googleapis.com/css2?family=Playfair+Display:ital,wght@0,400;0,700;1,400&display=swap" rel="stylesheet" />
     <link rel="stylesheet" href={`${import.meta.env.BASE_URL}styles/main.css`} />
   </head>
   <body>
     <div class="page">
-      <div id="logo">
-        <img src={`${import.meta.env.BASE_URL}images/expotus_logo.png`} alt="exPOTUS logo" />
-      </div>
-      <div id="tagline">Fun facts about ex-Presidents of the United States</div>
+      <header>
+        <div id="site-title"><a href={`${import.meta.env.BASE_URL}`}>exPOTUS<span class="site-tld">.com</span></a></div>
+        <div id="tagline">Fun facts about ex-Presidents of the United States</div>
+      </header>
       <slot />
     </div>
   </body>


### PR DESCRIPTION
Closes #1

## Summary

- Replace vellum texture / gray background with warm off-white (`#faf8f4`) editorial aesthetic
- Load Playfair Display via Google Fonts; apply to headings and site header
- Replace logo image with typographic `exPOTUS.com` header (`.com` styled smaller and in lighter navy)
- Navy color palette: `#1a2744` for headings/table headers, `#2c4a8c` for links
- Bump base font size to 16px, increase table padding, clean up nav bar
- Full CSS rewrite preserving all existing class names and sort indicator behavior

## Test plan

- [ ] All pages render correctly: index, facts, eras, about, a president detail page
- [ ] Column sorting still works (▲▼ indicators appear)
- [ ] Citations render
- [ ] Mobile layout looks good at ≤640px

🤖 Generated with [Claude Code](https://claude.com/claude-code)