### PR TITLE
Design tweaks and accessibility improvements

### DIFF
--- a/public/styles/main.css
+++ b/public/styles/main.css
@@ -17,6 +17,27 @@ body {
 }
 
 /* ============================================================
+   Skip link
+   ============================================================ */
+
+.skip-link {
+  position: absolute;
+  top: -100%;
+  left: 0;
+  background: #1a2744;
+  color: #fff;
+  padding: 8px 16px;
+  font-size: 14px;
+  font-weight: 600;
+  text-decoration: none;
+  z-index: 1000;
+}
+
+.skip-link:focus {
+  top: 0;
+}
+
+/* ============================================================
    Page layout
    ============================================================ */
 
@@ -167,6 +188,14 @@ a:hover {
   text-decoration: underline;
 }
 
+a:focus-visible {
+  color: #1a2744;
+  outline: 2px solid #2c4a8c;
+  outline-offset: 2px;
+  text-decoration: underline;
+  border-radius: 2px;
+}
+
 /* ============================================================
    Tables
    ============================================================ */
@@ -196,25 +225,39 @@ th {
   padding: 8px 10px;
 }
 
-th a:link, th a:visited, th a:hover {
-  color: #fff;
-  display: block;
-  text-decoration: none;
-  width: 100%;
-}
-
 th[data-sortable] {
   cursor: pointer;
 }
 
-th.asc a::after {
-  content: ' \25B2';
-  font-size: 8px;
+th[data-sortable] button {
+  background: none;
+  border: none;
+  color: #fff;
+  cursor: pointer;
+  font-family: inherit;
+  font-size: inherit;
+  font-weight: inherit;
+  letter-spacing: inherit;
+  padding: 0;
+  text-align: left;
+  text-transform: inherit;
+  width: 100%;
 }
 
-th.desc a::after {
-  content: ' \25BC';
+th[data-sortable] button:focus-visible {
+  outline: 2px solid #fff;
+  outline-offset: 2px;
+  border-radius: 2px;
+}
+
+.sort-indicator {
   font-size: 8px;
+  opacity: 0.5;
+}
+
+th.asc .sort-indicator,
+th.desc .sort-indicator {
+  opacity: 1;
 }
 
 .odd {

--- a/src/components/Nav.astro
+++ b/src/components/Nav.astro
@@ -7,22 +7,22 @@ const { active } = Astro.props;
 const base = import.meta.env.BASE_URL;
 ---
 
-<div class="nav">
+<nav class="nav" aria-label="Site">
   {active === 'presidents'
-    ? <span class="menuButton">ex-Presidents</span>
+    ? <span class="menuButton active" aria-current="page">ex-Presidents</span>
     : <span class="menuButton"><a href={`${base}`}>ex-Presidents</a></span>
   }
   {active === 'facts'
-    ? <span class="menuButton">Facts</span>
+    ? <span class="menuButton active" aria-current="page">Facts</span>
     : <span class="menuButton"><a href={`${base}facts/`}>Facts</a></span>
   }
   {active === 'eras'
-    ? <span class="menuButton">Eras</span>
+    ? <span class="menuButton active" aria-current="page">Eras</span>
     : <span class="menuButton"><a href={`${base}eras/`}>Eras</a></span>
   }
   {active === 'about'
-    ? <span class="menuButton">About</span>
+    ? <span class="menuButton active" aria-current="page">About</span>
     : <span class="menuButton"><a href={`${base}about/`}>About</a></span>
   }
   <slot />
-</div>
+</nav>

--- a/src/components/SortableTable.astro
+++ b/src/components/SortableTable.astro
@@ -19,13 +19,19 @@
     let ascending = true;
 
     headers.forEach((th) => {
-      th.style.cursor = 'pointer';
-      const link = document.createElement('a');
-      link.href = '#';
-      link.textContent = th.textContent;
-      link.addEventListener('click', (e) => e.preventDefault());
+      th.setAttribute('aria-sort', 'none');
+
+      const btn = document.createElement('button');
+      btn.textContent = th.textContent?.trim() ?? '';
+
+      const indicator = document.createElement('span');
+      indicator.setAttribute('aria-hidden', 'true');
+      indicator.className = 'sort-indicator';
+      indicator.textContent = ' \u2195';
+
+      btn.appendChild(indicator);
       th.textContent = '';
-      th.appendChild(link);
+      th.appendChild(btn);
 
       th.addEventListener('click', () => {
         const key = th.getAttribute('data-sortable')!;
@@ -36,9 +42,17 @@
           ascending = true;
         }
 
-        // Update header classes
-        headers.forEach((h) => h.classList.remove('asc', 'desc'));
+        // Update header classes, aria-sort, and indicators
+        headers.forEach((h) => {
+          h.classList.remove('asc', 'desc');
+          h.setAttribute('aria-sort', 'none');
+          const ind = h.querySelector('.sort-indicator');
+          if (ind) ind.textContent = ' \u2195';
+        });
         th.classList.add(ascending ? 'asc' : 'desc');
+        th.setAttribute('aria-sort', ascending ? 'ascending' : 'descending');
+        const ind = th.querySelector('.sort-indicator');
+        if (ind) ind.textContent = ascending ? ' \u25B2' : ' \u25BC';
 
         // Sort rows
         const rows = Array.from(tbody.querySelectorAll('tr'));
@@ -49,7 +63,6 @@
           const aVal = aCell.getAttribute('data-sort-value') || aCell.textContent || '';
           const bVal = bCell.getAttribute('data-sort-value') || bCell.textContent || '';
 
-          // Try numeric comparison first
           const aNum = parseFloat(aVal);
           const bNum = parseFloat(bVal);
           if (!isNaN(aNum) && !isNaN(bNum)) {

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -17,12 +17,15 @@ const { title = 'exPotus.com' } = Astro.props;
     <link rel="stylesheet" href={`${import.meta.env.BASE_URL}styles/main.css`} />
   </head>
   <body>
+    <a class="skip-link" href="#main-content">Skip to main content</a>
     <div class="page">
       <header>
         <div id="site-title"><a href={`${import.meta.env.BASE_URL}`}>exPOTUS<span class="site-tld">.com</span></a></div>
         <div id="tagline">Fun facts about ex-Presidents of the United States</div>
       </header>
-      <slot />
+      <main id="main-content">
+        <slot />
+      </main>
     </div>
   </body>
 </html>

--- a/src/pages/eras.astro
+++ b/src/pages/eras.astro
@@ -29,20 +29,19 @@ const base = import.meta.env.BASE_URL;
     <h1>Ex-Presidential Eras</h1>
     <p>
       This is a list of the times in history when the number of ex-presidents changed.
-      You can change how the list is sorted by clicking on the column headers.
     </p>
     <SortableTable>
       <table>
         <thead>
           <tr>
-            <th>#</th>
-            <th data-sortable="start">Start</th>
-            <th>End</th>
-            <th data-sortable="duration">Duration</th>
-            <th>Days</th>
-            <th data-sortable="count">Count</th>
-            <th>List</th>
-            <th>Change</th>
+            <th scope="col">#</th>
+            <th scope="col" data-sortable="start">Start</th>
+            <th scope="col">End</th>
+            <th scope="col" data-sortable="duration">Duration</th>
+            <th scope="col">Days</th>
+            <th scope="col" data-sortable="count">Count</th>
+            <th scope="col">List</th>
+            <th scope="col">Change</th>
           </tr>
         </thead>
         <tbody>

--- a/src/pages/facts.astro
+++ b/src/pages/facts.astro
@@ -25,15 +25,14 @@ const allFacts = sorted.flatMap((p) =>
     <h1>Ex-Presidential Facts</h1>
     <p>
       This is a list of facts about all ex-presidents.
-      You can change how the list is sorted by clicking on the column headers.
     </p>
     <SortableTable>
       <table>
         <thead>
           <tr>
-            <th data-sortable="president">Ex-President</th>
-            <th data-sortable="dates">Dates</th>
-            <th>Description</th>
+            <th scope="col" data-sortable="president">Ex-President</th>
+            <th scope="col" data-sortable="dates">Dates</th>
+            <th scope="col">Description</th>
           </tr>
         </thead>
         <tbody>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -16,19 +16,17 @@ const presidents = allPresidents
     <h1>Ex-Presidents of the United States</h1>
     <p>
       This is a list of all ex-Presidents of the United States and their periods of ex-presidency.
-      You can change how the list is sorted by clicking on the column headers.
-      To see details about an ex-president, click on his name.
     </p>
     <SortableTable>
       <table>
         <thead>
           <tr>
-            <th>#</th>
-            <th data-sortable="name">Name</th>
-            <th data-sortable="start">Start</th>
-            <th data-sortable="end">End</th>
-            <th data-sortable="duration">Duration</th>
-            <th data-sortable="days">Days</th>
+            <th scope="col">#</th>
+            <th scope="col" data-sortable="name">Name</th>
+            <th scope="col" data-sortable="start">Start</th>
+            <th scope="col" data-sortable="end">End</th>
+            <th scope="col" data-sortable="duration">Duration</th>
+            <th scope="col" data-sortable="days">Days</th>
           </tr>
         </thead>
         <tbody>

--- a/src/pages/presidents/[slug].astro
+++ b/src/pages/presidents/[slug].astro
@@ -51,8 +51,8 @@ const base = import.meta.env.BASE_URL;
       <table>
         <thead>
           <tr>
-            <th id="fact_dates">Dates</th>
-            <th id="fact_desc">Description</th>
+            <th scope="col">Dates</th>
+            <th scope="col">Description</th>
           </tr>
         </thead>
         <tbody>


### PR DESCRIPTION
## Summary

- Remove redundant instructional prose ("click to sort", "click a name to see details") from table pages — the ↕ sort indicator on column headers communicates the affordance visually
- Fix sortable table accessibility: replace `<a href="#">` with `<button>` (adds Space key support), add `aria-sort` attributes updated on click, move sort glyphs to `aria-hidden` spans so screen readers don't read them aloud
- Add `<main id="main-content">` landmark and a skip-to-content link for keyboard users
- Change nav `<div>` to `<nav aria-label="Site">` with `aria-current="page"` on the active item
- Add `:focus-visible` styles for links and sort buttons
- Add `scope="col"` to all table `<th>` elements

## Test plan

- [ ] Tab through the page with keyboard only — skip link appears on first Tab, focus ring is visible on all interactive elements
- [ ] Use a screen reader (VoiceOver/NVDA) — nav is announced as navigation, active page item reads "current page", sort columns announce ascending/descending direction
- [ ] Click/keyboard-activate sort headers — ↕ updates to ▲/▼, `aria-sort` attribute updates correctly
- [ ] Press Space on a focused sort header button — table sorts (was broken before)

🤖 Generated with [Claude Code](https://claude.com/claude-code)