### PR TITLE
Make ex-Presidents nav item a link on president detail pages

### DIFF
--- a/src/components/Nav.astro
+++ b/src/components/Nav.astro
@@ -1,6 +1,6 @@
 ---
 interface Props {
-  active: 'presidents' | 'facts' | 'eras' | 'about';
+  active: 'presidents' | 'president' | 'facts' | 'eras' | 'about';
 }
 
 const { active } = Astro.props;
@@ -10,7 +10,7 @@ const base = import.meta.env.BASE_URL;
 <nav class="nav" aria-label="Site">
   {active === 'presidents'
     ? <span class="menuButton active" aria-current="page">ex-Presidents</span>
-    : <span class="menuButton"><a href={`${base}`}>ex-Presidents</a></span>
+    : <span class="menuButton" class:list={[{active: active === 'president'}]}><a href={`${base}`}>ex-Presidents</a></span>
   }
   {active === 'facts'
     ? <span class="menuButton active" aria-current="page">Facts</span>

--- a/src/pages/presidents/[slug].astro
+++ b/src/pages/presidents/[slug].astro
@@ -25,7 +25,7 @@ const base = import.meta.env.BASE_URL;
 ---
 
 <Layout title={`${fullName} - exPotus.com`}>
-  <Nav active="presidents">
+  <Nav active="president">
     {prevSlug
       ? <span class="menuButton"><a href={`${base}presidents/${prevSlug}/`}>Previous</a></span>
       : <span class="menuButton">Previous</span>


### PR DESCRIPTION
## Summary
- Adds `'president'` (singular) as a valid `active` value in `Nav.astro`
- On president detail pages, the ex-Presidents nav item now renders as a clickable link back to the table, with active styling applied
- Updates `presidents/[slug].astro` to pass `active="president"` instead of `active="presidents"`

Closes #18

## Test plan
- [ ] Visit any individual president page and confirm the ex-Presidents nav item is a clickable link
- [ ] Confirm clicking it navigates back to the main presidents table
- [ ] Confirm the ex-Presidents item still appears visually highlighted (bold) on detail pages
- [ ] Confirm the ex-Presidents item is still non-linked and marked current on the index page

🤖 Generated with [Claude Code](https://claude.com/claude-code)