### PR TITLE
Add pre-commit hook to prevent direct commits to master

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,7 @@
+#!/bin/sh
+branch=$(git symbolic-ref --short HEAD 2>/dev/null)
+if [ "$branch" = "master" ]; then
+  echo "error: direct commits to 'master' are not allowed" >&2
+  echo "hint: create a feature branch first (e.g. git checkout -b my-branch)" >&2
+  exit 1
+fi

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "dev": "astro dev",
     "build": "astro build",
     "preview": "astro preview",
-    "audit-citations": "node scripts/audit-citations.js"
+    "audit-citations": "node scripts/audit-citations.js",
+    "prepare": "git config core.hooksPath .githooks"
   },
   "dependencies": {
     "astro": "^5.0.0"


### PR DESCRIPTION
## Summary

- Adds `.githooks/pre-commit` — a shell script that exits with an error if the current branch is `master`, blocking the commit
- Adds a `prepare` npm script that runs `git config core.hooksPath .githooks` on `npm install`, so the hook activates automatically for anyone who clones the repo

## Test plan

- [ ] Verify `git commit` on `master` is blocked with a clear error message
- [ ] Verify `git commit` on a feature branch succeeds normally
- [ ] Verify `npm install` activates the hook on a fresh clone (check `git config core.hooksPath`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)