### PR TITLE
Fix final era showing end date instead of present

### DIFF
--- a/src/lib/eras.ts
+++ b/src/lib/eras.ts
@@ -89,7 +89,9 @@ export function calculateEras(presidents: President[]): Era[] {
       previous.endTime = event.startTime;
 
       if (previous.startDate === event.startDate && previous.startTime === event.startTime) {
-        // Combine simultaneous events
+        // Combine simultaneous events; end is not yet known so reset it
+        previous.endDate = null;
+        previous.endTime = 0;
         if (event.added) {
           if (previous.added) {
             throw new Error(


### PR DESCRIPTION
## Summary

- The last row in the eras table showed an end date equal to its start date instead of "present"
- Root cause: the de-duplication loop in `src/lib/eras.ts` set `previous.endDate = event.startDate` before checking whether two events were simultaneous; the merged era was left with a non-null endDate
- Fix: reset `endDate` to `null` when combining simultaneous events

Closes #27