### PR TITLE
Add wrangler.jsonc for Cloudflare Workers deployment

### DIFF
--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -1,0 +1,7 @@
+{
+  "name": "expotus",
+  "compatibility_date": "2026-02-22",
+  "assets": {
+    "directory": "./dist"
+  }
+}


### PR DESCRIPTION
Adds `wrangler.jsonc` to configure Cloudflare Workers to serve the static site from the `./dist` build output directory.

This fixes the deploy error caused by Cloudflare not knowing where the built assets are. Using a Workers + assets setup (rather than Pages) also positions the project to add serverless functions when needed.

Closes #29

🤖 Generated with [Claude Code](https://claude.com/claude-code)